### PR TITLE
Potential fix for code scanning alert no. 5: Double escaping or unescaping

### DIFF
--- a/src/ticket-analyzer.ts
+++ b/src/ticket-analyzer.ts
@@ -253,9 +253,9 @@ export class TicketAnalyzer {
       .replace(/&nbsp;/g, ' ') // Replace &nbsp;
       .replace(/&lt;/g, '<') // Replace &lt;
       .replace(/&gt;/g, '>') // Replace &gt;
-      .replace(/&amp;/g, '&') // Replace &amp;
       .replace(/&quot;/g, '"') // Replace &quot;
       .replace(/&#39;/g, "'") // Replace &#39;
+      .replace(/&amp;/g, '&') // Replace &amp; (decode ampersand last to avoid double-unescaping)
       .replace(/\s+/g, ' ') // Normalize whitespace
       .trim();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/verygoodplugins/mcp-freescout/security/code-scanning/5](https://github.com/verygoodplugins/mcp-freescout/security/code-scanning/5)

In general, to avoid double unescaping, the escape character (`&` for HTML entities) must be unescaped *last*. That means in a sequence of `.replace` calls, do not decode `&amp;` until after all other entities have been decoded. Alternatively, delegate to a well‑tested HTML entity decoder that correctly handles ordering.

The minimally invasive fix here is to keep the current logic but reorder the `.replace` calls in `stripHtml` so that `&amp;` is handled last. This preserves existing behavior for tags, `&nbsp;`, and other entities, while eliminating the double‑unescape scenario flagged by CodeQL. Concretely, in `src/ticket-analyzer.ts`, lines 251–258 should be adjusted so that `.replace(/&amp;/g, '&')` comes after the `&quot;` and `&#39;` replacements. No extra imports or new helpers are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
