### PR TITLE
fix: use NPM_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,14 +54,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
       - run: npm run build
       - run: npm test
 
-      # Trusted Publishing: No NPM_TOKEN needed!
-      - run: npm publish --access public --provenance
+      # Trusted Publishing via OIDC - no NPM_TOKEN needed
+      - run: |
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   mcp-registry-publish:
     needs: [release-please, npm-publish]


### PR DESCRIPTION
OIDC trusted publishing isn't working. Fall back to token-based auth.