### PR TITLE
chore: standardize repo metadata and review workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge
+        if: |
+          steps.meta.outputs.update-type != 'version-update:semver-major' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          CURRENT_LOGIN="$(gh api user --jq .login)"
+          ALREADY_APPROVED="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq '[.[] | select(.user.login == "'"$CURRENT_LOGIN"'" and .state == "APPROVED")] | length')"
+          if [ "$ALREADY_APPROVED" -eq 0 ]; then
+            gh pr review --approve "$PR_URL"
+          fi
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-pr-title:
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate conventional PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\([[:alnum:]_.-]+\))?!?: .+'
+
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title must use Conventional Commits because squash merges become release-please input."
+          echo "Allowed prefixes: feat, fix, docs, chore, refactor, test, perf, build, ci, revert"
+          echo "Examples:"
+          echo "  fix: harden push approval auth flow"
+          echo "  feat(auth): add TOTP support"
+          exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   conventional-pr-title:
-    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate conventional PR title

--- a/README.md
+++ b/README.md
@@ -669,8 +669,12 @@ GPL-3.0 License - see LICENSE file for details
 For issues, questions, or suggestions:
 
 - [Open an issue on GitHub](https://github.com/verygoodplugins/mcp-freescout/issues)
-- [Contact the maintainers](https://verygoodplugins.com/contact?utm_source=github)
+- [Contact Very Good Plugins](https://verygoodplugins.com/contact/?utm_source=github)
 - Check the documentation
+
+---
+
+Built with 🧡 by [Very Good Plugins](https://verygoodplugins.com/?utm_source=github)
 
 ## Roadmap
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.verygoodplugins/mcp-freescout",
   "title": "MCP FreeScout",
   "description": "FreeScout ticket management with AI-powered analysis, search filters, and structured outputs.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "websiteUrl": "https://verygoodplugins.com/?utm_source=mcp-registry",
   "repository": {
     "url": "https://github.com/verygoodplugins/mcp-freescout",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@verygoodplugins/mcp-freescout",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- add the missing standard `pr-title` and `dependabot-auto-merge` workflows without disturbing mcp-freescout's existing CI, security, or release automation
- align `server.json` version metadata with the current `v2.0.1` release
- fix the README support footer to match the current VGP repo standard

## Test plan
- [x] `../mcp-ecosystem/scripts/audit-server.sh /Users/jgarturo/Projects/OpenAI/mcp-servers/mcp-freescout-standardize`
- [x] confirm existing CI/release/security workflows are preserved rather than replaced
- [ ] CI on this PR

## Notes
- I intentionally did **not** apply the full generated ecosystem diff here because the current repo has custom release/security behavior that still needs to be modeled in `mcp-ecosystem` before a broader sync would be safe.
- The source checkout at `/Users/jgarturo/Projects/OpenAI/mcp-servers/mcp-freescout` had unrelated local changes in `AGENTS.md`, so this PR was prepared from an isolated worktree.