### PR TITLE
chore(deps): consolidate dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2
     groups:
-      production-dependencies:
+      npm-version-updates:
+        applies-to: version-updates
         patterns:
           - "*"
-        exclude-patterns:
-          - "@types/*"
-          - "typescript"
-          - "vitest"
-          - "eslint*"
-          - "prettier"
-      dev-dependencies:
+      npm-security-updates:
+        applies-to: security-updates
         patterns:
-          - "@types/*"
-          - "typescript"
-          - "vitest"
-          - "eslint*"
-          - "prettier"
+          - "*"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Consolidates dependabot grouping into one version-update group and one security-update group per ecosystem to stop package-lock.json merge conflicts between open PRs.

Before: split production/dev groups created two PRs per run, each touching the lockfile; scoped names like `@eslint/js` slipped between the glob patterns.
After: one version-updates PR + one rolling security-updates PR per ecosystem. `open-pull-requests-limit` lowered to 2. Uses `applies-to` so advisories batch instead of opening individual PRs.

No runtime/build impact — Dependabot config only.