### PR TITLE
chore(ci): name workflow checks for org rulesets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,14 @@ on:
 
 jobs:
   test:
-    name: TypeScript CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -35,7 +34,7 @@ jobs:
           FREESCOUT_URL: ${{ secrets.FREESCOUT_URL }}
           FREESCOUT_API_KEY: ${{ secrets.FREESCOUT_API_KEY }}
         run: npm run test:integration
-        continue-on-error: true  # Cloudflare may block GitHub Actions IPs
+        continue-on-error: true # Cloudflare may block GitHub Actions IPs
 
       - name: Test coverage
         run: npm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -34,7 +34,7 @@ jobs:
           FREESCOUT_URL: ${{ secrets.FREESCOUT_URL }}
           FREESCOUT_API_KEY: ${{ secrets.FREESCOUT_API_KEY }}
         run: npm run test:integration
-        continue-on-error: true # Cloudflare may block GitHub Actions IPs
+        continue-on-error: true  # Cloudflare may block GitHub Actions IPs
 
       - name: Test coverage
         run: npm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: TypeScript CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   conventional-pr-title:
+    name: Lint PR Title
     if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- add an explicit `TypeScript CI` check name to the existing CI job
- add an explicit `Lint PR Title` check name to the existing PR-title job
- keep FreeScout's current CI behavior intact while aligning check contexts for org rulesets

## Test plan
- [x] `npm run build`
- [x] `npm test`