### PR TITLE
fix(release): use npm trusted publishing without token auth

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,18 +53,15 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
       - run: npm run build
       - run: npm test
 
-      # Trusted Publishing via OIDC - no NPM_TOKEN needed
-      - run: |
-          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted Publishing via OIDC - no npm token secret required
+      - run: npm publish --access public --provenance
 
   mcp-registry-publish:
     needs: [release-please, npm-publish]


### PR DESCRIPTION
## Summary
- switch the Release Please publish job to actual npm trusted publishing
- remove the stale token-based npm auth path
- keep the existing release flow, but stop depending on `NPM_TOKEN`

## Test plan
- [x] npm ci
- [x] npm run build
- [x] npm test