### PR TITLE
fix: remove outputSchema from remaining tools (draft-07 rejected by clients)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ FREESCOUT_DEFAULT_USER_ID=1
 
 **Add a new tool:**
 
-1. Call `server.registerTool(name, { title, description, inputSchema }, handler)` in `src/index.ts`. `inputSchema` is a Zod shape; add `outputSchema` only if the response is reliably structured (some tools omit it because raw API responses have optional/undefined fields).
+1. Call `server.registerTool(name, { title, description, inputSchema }, handler)` in `src/index.ts`. `inputSchema` is a Zod shape. Do not declare `outputSchema`: the MCP SDK converts it to JSON Schema draft-07, and clients that validate tool schemas against 2020-12 (Claude Code among them) refuse to register the tool. Return the payload in `content`, plus `structuredContent` when the response is reliably structured.
 2. Implement the underlying API call as a method on `FreeScoutAPI` in `freescout-api.ts`.
 3. Add or extend Zod schemas / types in `types.ts`.
 4. Add tests under `src/__tests__/`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from './draft-recipients.js';
 import { FreeScoutAPI } from './freescout-api.js';
 import { TicketAnalyzer } from './ticket-analyzer.js';
-import { TicketAnalysisSchema, SearchFiltersSchema, type FreeScoutRecipients } from './types.js';
+import { SearchFiltersSchema, type FreeScoutRecipients } from './types.js';
 import { loadEnv } from './env.js';
 
 type PackageJson = { version: string };
@@ -78,6 +78,9 @@ server.registerTool(
 );
 
 // Tool 2: Analyze Ticket
+// Note: outputSchema removed because the MCP SDK converts it to JSON Schema
+// draft-07, which clients that validate against 2020-12 reject outright.
+// The payload is still returned in content and structuredContent.
 server.registerTool(
   'freescout_analyze_ticket',
   {
@@ -87,7 +90,6 @@ server.registerTool(
     inputSchema: {
       ticket: z.string().describe('Ticket ID, ticket number, or FreeScout URL'),
     },
-    outputSchema: TicketAnalysisSchema,
   },
   async ({ ticket }) => {
     const ticketId = api.parseTicketInput(ticket);
@@ -102,6 +104,7 @@ server.registerTool(
 );
 
 // Tool 3: Add Note
+// Note: outputSchema removed for the same draft-07 dialect reason as above.
 server.registerTool(
   'freescout_add_note',
   {
@@ -111,11 +114,6 @@ server.registerTool(
       ticket: z.string().describe('Ticket ID, ticket number, or FreeScout URL'),
       note: z.string().describe('The note content to add'),
       userId: z.number().optional().describe('User ID for the note (default: from env)'),
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string(),
-      ticketId: z.string(),
     },
   },
   async ({ ticket, note, userId }) => {
@@ -138,6 +136,7 @@ server.registerTool(
 );
 
 // Tool 4: Update Ticket
+// Note: outputSchema removed for the same draft-07 dialect reason as above.
 server.registerTool(
   'freescout_update_ticket',
   {
@@ -150,11 +149,6 @@ server.registerTool(
         .optional()
         .describe('New ticket status'),
       assignTo: z.number().optional().describe('User ID to assign the ticket to'),
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string(),
-      ticketId: z.string(),
     },
   },
   async ({ ticket, status, assignTo }) => {
@@ -184,6 +178,7 @@ server.registerTool(
 );
 
 // Tool 5: Create Draft Reply
+// Note: outputSchema removed for the same draft-07 dialect reason as above.
 server.registerTool(
   'freescout_create_draft_reply',
   {
@@ -208,12 +203,6 @@ server.registerTool(
         .array(z.string().email())
         .optional()
         .describe('Optional BCC recipients. Omit to preserve existing recipients; pass [] to clear.'),
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string(),
-      ticketId: z.string(),
-      draftId: z.number(),
     },
   },
   async ({ ticket, replyText, userId, to, cc, bcc }) => {


### PR DESCRIPTION
Closes #73

## Problem

Four tools still declare `outputSchema`. The MCP SDK converts it to JSON Schema draft-07, and clients that validate tool schemas against 2020-12 only reject the tool before any request reaches the server:

```
Error: Tool "freescout_create_draft_reply" has an invalid outputSchema:
JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#").
The default validator supports JSON Schema 2020-12 only.
```

Affected tools: `freescout_analyze_ticket`, `freescout_add_note`, `freescout_update_ticket`, `freescout_create_draft_reply`. That is every write path, so in Claude Code the server ends up read-only while the other five tools work fine.

The dialect cannot be chosen from the server side. In `@modelcontextprotocol/sdk` 1.30.0, `server/mcp.js` converts the schema with `toJsonSchemaCompat(obj, { strictUnions: true, pipeStrategy: 'output' })` and never passes a `target`, and `server/zod-json-schema-compat.js` falls back to `draft-7` for both the Zod v3 and the Zod v4 branch.

## Change

Drop `outputSchema` from the four remaining tools, consistent with the tools where it was already removed in #17 and #18. `structuredContent` is kept where it was already returned: with no declared output schema the SDK skips output validation, and clients that read structured results still get the same payload.

`AGENTS.md` gets one line so the guidance for new tools matches the constraint.

## Verification

`npm run lint`, `npm run build` and `npm test` (40 tests) pass.

`tools/list` over stdio, before and after the change:

| tool | before | after |
| --- | --- | --- |
| `freescout_analyze_ticket` | `$schema: draft-07` | no `outputSchema` |
| `freescout_add_note` | `$schema: draft-07` | no `outputSchema` |
| `freescout_update_ticket` | `$schema: draft-07` | no `outputSchema` |
| `freescout_create_draft_reply` | `$schema: draft-07` | no `outputSchema` |

`tools/call` for `freescout_add_note` and `freescout_update_ticket` against a local stub FreeScout: no SDK error, `content` unchanged, and `structuredContent` still delivered (`{"success":true,"message":"Note added to ticket #123","ticketId":"123"}`).

`npm run test:integration` was not run: it needs a reachable FreeScout instance and the ones available here are production.

Happy to add a stdio regression test asserting that no tool advertises an `outputSchema`, if you want a guard in CI rather than a comment.
