### PR TITLE
feat: support userId in freescout_update_ticket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ The server registers **8 tools**, all prefixed `freescout_`. (There are no Git/G
 1. **freescout_get_ticket** — Fetch a ticket by ID, number, or URL, optionally with all conversation threads (`includeThreads`, default true).
 2. **freescout_analyze_ticket** — Analyze a ticket to determine issue type, root cause, and suggested solution (returns structured `TicketAnalysis`).
 3. **freescout_add_note** — Add an internal note to a ticket (`userId` defaults to env).
-4. **freescout_update_ticket** — Update ticket `status` (`active`/`pending`/`closed`/`spam`) and/or `assignTo` (user ID).
+4. **freescout_update_ticket** — Update ticket `status` (`active`/`pending`/`closed`/`spam`) and/or `assignTo` (user ID). `userId` sets the FreeScout `byUser` so the activity log credits the right agent (defaults to env).
 5. **freescout_create_draft_reply** — Create a review-before-send draft reply. Optional `to`/`cc`/`bcc`: omit to inherit existing recipients, pass `[]` to clear.
 6. **freescout_get_ticket_context** — Get condensed ticket + customer context to help draft personalized replies.
 7. **freescout_search_tickets** — Search with explicit filters (`textSearch`, `assignee` `"unassigned"`/`"any"`/number, `updatedSince`/`createdSince` ISO or relative like `7d`/`24h`, `mailboxId`, `status`, `state`, `page`/`pageSize`, `includeLastMessage`).

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Update ticket status and/or assignment.
 - `ticket` (required): Ticket ID, number, or FreeScout URL
 - `status` (optional): New status ('active', 'pending', 'closed', 'spam')
 - `assignTo` (optional): User ID to assign the ticket to
+- `userId` (optional): User ID performing the update (defaults to env setting)
+
+FreeScout credits status and assignment changes to the user sent as `byUser`, so `userId` decides who shows up in the ticket activity log. Without it the change is attributed to `FREESCOUT_DEFAULT_USER_ID`, even when another agent made it.
 
 **Natural Language Examples:**
 
@@ -245,6 +248,7 @@ Update ticket status and/or assignment.
 - "Assign this ticket to user ID 2"
 - "Set ticket status to active"
 - "Update ticket #12345 status to closed and assign to user 1"
+- "Close ticket #12345 on behalf of user 2"
 
 #### `freescout_create_draft_reply`
 

--- a/src/__tests__/freescout-api.test.ts
+++ b/src/__tests__/freescout-api.test.ts
@@ -287,6 +287,22 @@ describe('FreeScoutAPI', () => {
       );
     });
 
+    it('should forward byUser so FreeScout attributes the change', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+
+      await api.updateConversation('123', { status: 'closed', byUser: 7 });
+
+      const requestInit = mockFetch.mock.calls[0][1] as { body: string };
+      expect(JSON.parse(requestInit.body)).toEqual({
+        status: 'closed',
+        byUser: 7,
+      });
+    });
+
     it('should handle update failures', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,12 @@ server.registerTool(
         .optional()
         .describe('New ticket status'),
       assignTo: z.number().optional().describe('User ID to assign the ticket to'),
+      userId: z
+        .number()
+        .optional()
+        .describe(
+          'User ID performing the update, so FreeScout attributes it to that agent in the activity log (defaults to env setting)'
+        ),
     },
     outputSchema: {
       success: z.boolean(),
@@ -157,14 +163,15 @@ server.registerTool(
       ticketId: z.string(),
     },
   },
-  async ({ ticket, status, assignTo }) => {
+  async ({ ticket, status, assignTo, userId }) => {
     const ticketId = api.parseTicketInput(ticket);
+    const actualUserId = userId ?? DEFAULT_USER_ID;
 
     const updates: {
       status?: 'active' | 'pending' | 'closed' | 'spam';
       assignTo?: number;
       byUser?: number;
-    } = { byUser: DEFAULT_USER_ID };
+    } = { byUser: actualUserId };
     if (status) updates.status = status;
     if (assignTo) updates.assignTo = assignTo;
 


### PR DESCRIPTION
Closes #48

## Problem

`freescout_update_ticket` hardcodes `byUser` to `FREESCOUT_DEFAULT_USER_ID`. FreeScout credits a conversation update to whoever is passed as `byUser` (the API marks it required when changing `status`, `assignTo` or `mailboxId`), so every status change shows up in the ticket activity log under the default user, no matter which agent made it.

## Change

Accept an optional `userId` on `freescout_update_ticket` and forward it as `byUser`, mirroring `freescout_add_note` and `freescout_create_draft_reply`. Omitting it keeps the current behaviour, so nothing changes for existing callers.

```json
{ "ticket": "2582", "status": "active", "userId": 2 }
```

`FreeScoutAPI.updateConversation` already accepted `byUser`, so the API client is unchanged.

## Verification

`npm run lint`, `npm run build` and `npm test` (41 tests, one added) pass.

Unit test: `updateConversation` puts `byUser` in the PUT body.

End to end over stdio against a local stub FreeScout that records the outgoing request:

- `{"ticket":"123","status":"closed","userId":42}` → `PUT /api/conversations/123 {"byUser":42,"status":"closed"}`
- `{"ticket":"123","status":"closed"}` → `PUT /api/conversations/123 {"byUser":1,"status":"closed"}` (env default, unchanged)

Live check on a self-hosted FreeScout (1.8.x), on a throwaway ticket, driving the built server over stdio like a real client. Starting status `active`, `FREESCOUT_DEFAULT_USER_ID` unset so the default is user 1:

- `{"status":"pending","userId":10}` → the new `lineitem` thread comes back with `action.type: changed-ticket-status`, `status: pending`, `createdBy.id: 10`, and the activity log line names user 10.
- `{"status":"active","userId":2}` → same, `createdBy.id: 2`, activity log names user 2.

So `byUser` does drive activity log attribution, and the ticket ended up back in its original state.

One thing that showed up during that check, pre-existing on `main` and unrelated to this change: the update endpoint answers `204 No Content` with an empty body, while `FreeScoutAPI.request` always calls `response.json()`. The update is applied, but the tool reports `isError: true` with `Unexpected end of JSON input`. Happy to open a separate issue or PR for it — it seemed better not to fold an error-handling fix into this one.

`npm run test:integration` was not run: it needs a reachable FreeScout instance and the ones available here are production.

Independent from #74, which removes the `outputSchema` declarations. The two touch adjacent lines in this tool's registration, so whichever lands second may need a trivial rebase.
