### PR TITLE
fix: handle 204 No Content from the FreeScout API

### DIFF
--- a/src/__tests__/freescout-api.test.ts
+++ b/src/__tests__/freescout-api.test.ts
@@ -287,6 +287,20 @@ describe('FreeScoutAPI', () => {
       );
     });
 
+    it('should resolve on a 204 response with an empty body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => {
+          throw new Error('Unexpected end of JSON input');
+        },
+      });
+
+      await expect(
+        api.updateConversation('123', { status: 'closed', byUser: 1 })
+      ).resolves.toEqual({});
+    });
+
     it('should handle update failures', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/src/freescout-api.ts
+++ b/src/freescout-api.ts
@@ -320,6 +320,12 @@ export class FreeScoutAPI {
           throw new Error(`FreeScout API error: ${response.status} - ${errorText}`);
         }
 
+        // Updating a conversation answers 204 with an empty body, which
+        // response.json() cannot parse.
+        if (response.status === 204) {
+          return {} as T;
+        }
+
         return response.json() as Promise<T>;
       } catch (error: unknown) {
         clearTimeout(timeoutId);


### PR DESCRIPTION
Closes #76

## Problem

`PUT /api/conversations/{id}` answers `204 No Content` with an empty body, and `FreeScoutAPI.request` always calls `response.json()`. The parse throws, so `freescout_update_ticket` reports `isError: true` with `Unexpected end of JSON input` on updates that actually went through.

## Change

Return an empty object when the response is `204`, before touching the body. The other endpoints the client uses answer `200`/`201` with JSON and are unaffected, and no method signature changes.

## Verification

`npm run lint`, `npm run build` and `npm test` (41 tests, one added for the 204 path) pass.

Live, over stdio against a self-hosted FreeScout 1.8.233, same call before and after the change:

```
before: <<< {"content":[{"type":"text","text":"Unexpected end of JSON input"}],"isError":true}
after:  <<< {"content":[{"type":"text","text":"Ticket #3704 updated successfully"}],
             "structuredContent":{"success":true,"message":"Ticket #3704 updated successfully","ticketId":"3704"}}
```

In both cases the ticket status changed, so the difference is only in what the tool reports. The test ticket was put back in its original state afterwards.

`npm run test:integration` was not run: it needs a reachable FreeScout instance and the ones available here are production.

Independent from #74 and #75; this one only touches `freescout-api.ts`.
