### PR TITLE
fix(cli): resolve symlinked executable entry point

### DIFF
--- a/src/__tests__/cli-entrypoint.test.ts
+++ b/src/__tests__/cli-entrypoint.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { afterEach, expect, it } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+const distEntryPoint = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true }))
+  );
+});
+
+it('starts when npm invokes the executable through a symlink', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'mcp-freescout-cli-'));
+  temporaryDirectories.push(directory);
+  const executable = join(directory, 'mcp-freescout');
+  await symlink(distEntryPoint, executable);
+
+  const child = spawn(process.execPath, [executable], {
+    env: {
+      ...process.env,
+      FREESCOUT_URL: 'https://example.invalid',
+      FREESCOUT_API_KEY: 'test-only-key',
+      FREESCOUT_DEFAULT_USER_ID: '1',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  try {
+    const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      let stdout = '';
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`CLI initialize timed out: ${stderr}`));
+        }
+      }, 5_000);
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+        if (!settled && stdout.includes('protocolVersion')) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve(JSON.parse(stdout.trim()) as Record<string, unknown>);
+        }
+      });
+      child.on('error', reject);
+      child.on('exit', (code) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error(`CLI exited ${code}: ${stderr}`));
+        }
+      });
+      child.stdin.write(
+        `${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2026-06-18',
+            capabilities: {},
+            clientInfo: { name: 'cli-entrypoint-test', version: '1.0.0' },
+          },
+        })}\n`
+      );
+    });
+
+    expect(response).toMatchObject({
+      id: 1,
+      jsonrpc: '2.0',
+      result: { serverInfo: { name: 'mcp-freescout' } },
+    });
+  } finally {
+    child.stdin.end();
+    child.kill('SIGTERM');
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/server';
 import { serveStdio, type ServeStdioOptions } from '@modelcontextprotocol/server/stdio';
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { z } from 'zod';
@@ -479,6 +480,6 @@ function main(): void {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) {
   main();
 }


### PR DESCRIPTION
## Summary
- resolve the npm `.bin` symlink before checking whether the CLI is the entry module
- add a regression test that launches the compiled server through a symlink and completes stdio initialization

## Breaking changes
- None.

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`

Fixes the v3.0.0 installed CLI startup regression.